### PR TITLE
Fix typo: command -v sk

### DIFF
--- a/fuzzypkg
+++ b/fuzzypkg
@@ -6,7 +6,7 @@ HEADER="[ENTER] Add/Remove selected [TAB] Toggle selection [ALT-F] File list [AL
 if command -v fzf > /dev/null 2>&1; then
   FUZZYSEL=fzf
   export FZF_DEFAULT_OPTS="--inline-info --marker=M"
-elif command -f sk > /dev/null 2>&1; then
+elif command -v sk > /dev/null 2>&1; then
   FUZZYSEL=sk
   export SKIM_DEFAULT_OPTIONS="--inline-info"
 else


### PR DESCRIPTION
Just a small typo, it does not work with sk and warn `Unable to find fuzzy selector [fzf, sk]` because of this when only have sk installed.

You can also just close this PR and fix this typo in your next commit if you don't want typo fixes in a dedicate commit.