### PR TITLE
Add fallback for xq and remove xtools dependency

### DIFF
--- a/fuzzypkg
+++ b/fuzzypkg
@@ -41,6 +41,29 @@ column_wrap() {
   echo -e "${footer//^/${pad}}"
 }
 
+# Emulate xq behavior: Info, Dependencies, Required By
+fallback_xq() {
+  local pkg="$1"
+  local info
+
+  info="$(xbps-query -R -S "$pkg" 2>&1)"
+
+  # Emulate 'totop' logic: print specific fields first, then the rest
+  echo "$info" | grep "^short_desc"
+  echo "$info" | grep "^pkgver"
+  # Print the rest, excluding the fields we already printed to avoid duplicates
+  echo "$info" | grep -v -E "^(short_desc|pkgver)"
+
+  xbps-query -R -x "$pkg" | sed 's/^/	/;1s/^/depends:\n/'
+
+  local revdep
+  revdep=$(xbps-query -R -X "$pkg" | sed 's/^/	/')
+  if [ -n "$revdep" ]; then
+    printf "required-by:\n%s\n" "$revdep"
+  fi
+}
+export -f fallback_xq
+
 
 main() {
   trap delay_exit EXIT
@@ -61,6 +84,13 @@ main() {
       break
     fi
   done
+
+  # Check if XQ_BIN is available
+  if command -v "${XQ_BIN}" >/dev/null 2>&1; then
+    PREVIEW_CMD="${XQ_BIN} {2}"
+  else
+    PREVIEW_CMD="bash -c 'fallback_xq {2}'"
+  fi
 
   [ -z "${HIDE_DETAILS}" ] && SHOW_DETAILS="nohidden"
   [ -z "${HIDE_HEADER}" ] && SHOW_HEADER=1
@@ -99,7 +129,7 @@ main() {
         --marker="M" \
         --no-separator \
         --border-label=" Available Packages " \
-        --preview="${XQ_BIN} {2}" \
+        --preview="${PREVIEW_CMD} {2}" \
         --preview-window="down:wrap:${PREVIEW_BORDER:-border-sharp}:${SHOW_DETAILS}" \
         --preview-label=" Package Details " \
         --bind "${PD_KEY}:toggle-preview" \


### PR DESCRIPTION
I use [void on servers](https://github.com/Jipok/void-infect), including low-end VPSs where space is tight. I recently discovered I had `perl` installed, which was pulled in as a `git` dependency. I don't need either, and they take up space. Git is a dependency for `xtools`. And `xtools` is an unnecessary dependency for your script.
I've had your script for over five years and can't imagine living without it. I could package it for [my repository](https://void-repo.jipok.ru/), or just download a patched version manually, but I prefer a cleaner solution.
<img width="811" height="475" alt="изображение" src="https://github.com/user-attachments/assets/8acb338c-8428-4ddc-8a0e-b8e5b8e7fff2" />
Could you please remove the dependency on xtools from the package?